### PR TITLE
Add feature generation JFR event

### DIFF
--- a/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/api/FeatureGenerationEvent.java
+++ b/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/api/FeatureGenerationEvent.java
@@ -1,0 +1,51 @@
+package eu.jacobsjo.worldgendevtools.jfrprofiling.api;
+
+import jdk.jfr.*;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.profiling.jfr.JfrProfiler;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.GenerationStep;
+
+import java.util.Locale;
+
+@Name(FeatureGenerationEvent.EVENT_NAME)
+@Label("Feature Placement")
+@Category({JfrProfiler.ROOT_CATEGORY, JfrProfiler.WORLD_GEN_CATEGORY})
+public class FeatureGenerationEvent extends Event {
+    public static final String EVENT_NAME = "minecraft.FeaturePlacement";
+    public static final EventType TYPE = EventType.getEventType(FeatureGenerationEvent.class);
+
+    @Name(value="chunkPosX")
+    @Label(value="Chunk X Position")
+    public final int chunkPosX;
+
+    @Name(value="chunkPosZ")
+    @Label(value="Chunk Z Position")
+    public final int chunkPosZ;
+
+    @Name(value="level")
+    @Label(value="Level")
+    public final String level;
+
+    @Name(value="step")
+    @Label(value="Step")
+    public final int step;
+
+    @Name(value="stepName")
+    @Label(value="Step Name")
+    public final String stepName;
+
+    @Name(value="placedFeature")
+    @Label(value="Placed Feature")
+    public final String placedFeature;
+
+    public FeatureGenerationEvent(ChunkPos chunkPos, ResourceKey<Level> level, String placedFeature, int step) {
+        this.chunkPosX = chunkPos.x;
+        this.chunkPosZ = chunkPos.z;
+        this.level = level.location().toString();
+        this.placedFeature = placedFeature;
+        this.step = step;
+        this.stepName = GenerationStep.Decoration.values()[step].name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/ChunkGeneratorMixin.java
@@ -1,41 +1,31 @@
 package eu.jacobsjo.worldgendevtools.jfrprofiling.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import eu.jacobsjo.worldgendevtools.jfrprofiling.api.FeatureGenerationEvent;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
-import net.minecraft.world.level.StructureManager;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ChunkGenerator.class)
 public class ChunkGeneratorMixin {
-    @Inject(
-            method="applyBiomeDecoration",
+    @WrapOperation(
+            method = "applyBiomeDecoration",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/placement/PlacedFeature;placeWithBiomeCheck(Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/util/RandomSource;Lnet/minecraft/core/BlockPos;)Z")
     )
-    private void applyBiomeDecoration(WorldGenLevel level, ChunkAccess chunk, StructureManager structureManager, CallbackInfo ci, @Local(ordinal = 1) Registry<PlacedFeature> placedFeatureRegistry, @Local PlacedFeature placedFeature, @Local(ordinal = 2) int step, @Share("event") LocalRef<FeatureGenerationEvent> eventRef) {
+    private boolean profilePlaceWithBiomeCheck(PlacedFeature placedFeature, WorldGenLevel level, ChunkGenerator generator, RandomSource random, BlockPos pos, Operation<Boolean> original, @Local(argsOnly = true) ChunkAccess chunk, @Local(ordinal = 1) Registry<PlacedFeature> placedFeatureRegistry, @Local(ordinal = 2) int step){
         String featureKey = placedFeatureRegistry.getResourceKey(placedFeature).map(k -> k.location().toString()).orElse("unregistered");
         FeatureGenerationEvent event = new FeatureGenerationEvent(chunk.getPos(), level.getLevel().dimension(), featureKey, step);
         event.begin();
-        eventRef.set(event);
-    }
-
-    @Inject(
-            method="applyBiomeDecoration",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/placement/PlacedFeature;placeWithBiomeCheck(Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/util/RandomSource;Lnet/minecraft/core/BlockPos;)Z", shift = At.Shift.AFTER)
-    )
-    private void applyBiomeDecorationCommit(WorldGenLevel level, ChunkAccess chunk, StructureManager structureManager, CallbackInfo ci, @Share("event") LocalRef<FeatureGenerationEvent> eventRef) {
-        FeatureGenerationEvent event = eventRef.get();
-        if (event != null) {
-            event.commit();
-        }
+        boolean result = original.call(placedFeature, level, generator, random, pos);
+        event.commit();
+        return result;
     }
 }

--- a/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/ChunkGeneratorMixin.java
@@ -1,0 +1,41 @@
+package eu.jacobsjo.worldgendevtools.jfrprofiling.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import eu.jacobsjo.worldgendevtools.jfrprofiling.api.FeatureGenerationEvent;
+import net.minecraft.core.Registry;
+import net.minecraft.world.level.StructureManager;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChunkGenerator.class)
+public class ChunkGeneratorMixin {
+    @Inject(
+            method="applyBiomeDecoration",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/placement/PlacedFeature;placeWithBiomeCheck(Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/util/RandomSource;Lnet/minecraft/core/BlockPos;)Z")
+    )
+    private void applyBiomeDecoration(WorldGenLevel level, ChunkAccess chunk, StructureManager structureManager, CallbackInfo ci, @Local(ordinal = 1) Registry<PlacedFeature> placedFeatureRegistry, @Local PlacedFeature placedFeature, @Local(ordinal = 2) int step, @Share("event") LocalRef<FeatureGenerationEvent> eventRef) {
+        String featureKey = placedFeatureRegistry.getResourceKey(placedFeature).map(k -> k.location().toString()).orElse("unregistered");
+        FeatureGenerationEvent event = new FeatureGenerationEvent(chunk.getPos(), level.getLevel().dimension(), featureKey, step);
+        event.begin();
+        eventRef.set(event);
+    }
+
+    @Inject(
+            method="applyBiomeDecoration",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/placement/PlacedFeature;placeWithBiomeCheck(Lnet/minecraft/world/level/WorldGenLevel;Lnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/util/RandomSource;Lnet/minecraft/core/BlockPos;)Z", shift = At.Shift.AFTER)
+    )
+    private void applyBiomeDecorationCommit(WorldGenLevel level, ChunkAccess chunk, StructureManager structureManager, CallbackInfo ci, @Share("event") LocalRef<FeatureGenerationEvent> eventRef) {
+        FeatureGenerationEvent event = eventRef.get();
+        if (event != null) {
+            event.commit();
+        }
+    }
+}

--- a/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/JfrProfilerMixin.java
+++ b/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/JfrProfilerMixin.java
@@ -1,28 +1,19 @@
 package eu.jacobsjo.worldgendevtools.jfrprofiling.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import eu.jacobsjo.worldgendevtools.jfrprofiling.api.FeatureGenerationEvent;
 import jdk.jfr.Event;
 import net.minecraft.util.profiling.jfr.JfrProfiler;
-import net.minecraft.util.profiling.jfr.event.*;
-import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Mixin(JfrProfiler.class)
 public class JfrProfilerMixin {
-
-    @Shadow
-    @Final
-    @Mutable
-    private static final List<Class<? extends Event>> CUSTOM_EVENTS = List.of(
-            ChunkGenerationEvent.class,
-            ChunkRegionReadEvent.class,
-            ChunkRegionWriteEvent.class,
-            PacketReceivedEvent.class,
-            PacketSentEvent.class,
-            NetworkSummaryEvent.class,
-            ServerTickTimeEvent.class,
-            WorldLoadFinishedEvent.class,
-            FeatureGenerationEvent.class
-    );
+    @ModifyExpressionValue(method = "<clinit>", at = @At(value = "INVOKE", target = "Ljava/util/List;of(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/List;"))
+    private static List<Class<? extends Event>> addEvent(List<Class<? extends Event>> original){
+        return Stream.concat(original.stream(), Stream.of(FeatureGenerationEvent.class)).toList();
+    }
 }

--- a/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/JfrProfilerMixin.java
+++ b/src/main/java/eu/jacobsjo/worldgendevtools/jfrprofiling/mixin/JfrProfilerMixin.java
@@ -1,0 +1,28 @@
+package eu.jacobsjo.worldgendevtools.jfrprofiling.mixin;
+
+import eu.jacobsjo.worldgendevtools.jfrprofiling.api.FeatureGenerationEvent;
+import jdk.jfr.Event;
+import net.minecraft.util.profiling.jfr.JfrProfiler;
+import net.minecraft.util.profiling.jfr.event.*;
+import org.spongepowered.asm.mixin.*;
+
+import java.util.List;
+
+@Mixin(JfrProfiler.class)
+public class JfrProfilerMixin {
+
+    @Shadow
+    @Final
+    @Mutable
+    private static final List<Class<? extends Event>> CUSTOM_EVENTS = List.of(
+            ChunkGenerationEvent.class,
+            ChunkRegionReadEvent.class,
+            ChunkRegionWriteEvent.class,
+            PacketReceivedEvent.class,
+            PacketSentEvent.class,
+            NetworkSummaryEvent.class,
+            ServerTickTimeEvent.class,
+            WorldLoadFinishedEvent.class,
+            FeatureGenerationEvent.class
+    );
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,7 @@
     "worldgendevtools.loggingimprovements.mixins.json",
     "worldgendevtools.profiling.mixins.json",
     "worldgendevtools.locatefeature.mixins.json",
+    "worldgendevtools.jfrprofiling.mixins.json",
     {
       "config": "worldgendevtools.client.reloadregistries.mixins.json",
       "environment": "client"

--- a/src/main/resources/worldgendevtools.jfrprofiling.mixins.json
+++ b/src/main/resources/worldgendevtools.jfrprofiling.mixins.json
@@ -1,0 +1,15 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "eu.jacobsjo.worldgendevtools.jfrprofiling.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "ChunkGeneratorMixin",
+    "JfrProfilerMixin"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Adds the feature JFR event from [worldgen-profiling](https://github.com/misode/worldgen-profiling). I intentionally left out the surface event because it basically already exists in vanilla.

As for the implementation, I decided to put this in its own package because it feels very separate to the existing `profiling` package.

Also ideally I want to find a better way to add the event to the `CUSTOM_EVENTS` static field.