### PR TITLE
Fix: include Fabric dynamic registries in reload cycle.

### DIFF
--- a/src/main/java/eu/jacobsjo/worldgendevtools/reloadregistries/impl/RegistryReloader.java
+++ b/src/main/java/eu/jacobsjo/worldgendevtools/reloadregistries/impl/RegistryReloader.java
@@ -8,6 +8,7 @@ import com.mojang.serialization.Lifecycle;
 import eu.jacobsjo.util.TextUtil;
 import eu.jacobsjo.worldgendevtools.reloadregistries.api.ReloadableRegistry;
 import eu.jacobsjo.worldgendevtools.reloadregistries.api.UpdatableGeneratorChunkMap;
+import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.*;
 import net.minecraft.core.registries.Registries;
@@ -71,10 +72,10 @@ public class RegistryReloader {
         RegistryAccess.Frozen worldgenNewLayer = registries.getLayer(RegistryLayer.WORLDGEN);
         RegistryOps.RegistryInfoLookup worldgenLookup = getRegistrtyInfoLookup(worldgenContextLayer, worldgenNewLayer, true);
 
-        RegistryDataLoader.WORLDGEN_REGISTRIES.forEach((RegistryDataLoader.RegistryData<?> data) -> loadData(worldgenLookup, resourceManager, data, worldgenNewLayer, exceptionMap));
+        DynamicRegistries.getDynamicRegistries().forEach((RegistryDataLoader.RegistryData<?> data) -> loadData(worldgenLookup, resourceManager, data, worldgenNewLayer, exceptionMap));
 
         List<IllegalStateException> freezingExceptions = new ArrayList<>();
-        RegistryDataLoader.WORLDGEN_REGISTRIES.forEach((RegistryDataLoader.RegistryData<?> data) -> {
+        DynamicRegistries.getDynamicRegistries().forEach((RegistryDataLoader.RegistryData<?> data) -> {
             try {
                 Registry<?> registry = worldgenNewLayer.lookupOrThrow(data.key());
                 registry.freeze();


### PR DESCRIPTION
RegistryReloader.getRegistrtyInfoLookup() calls startReload() on all  registries in the WORLDGEN layer (including Fabric dynamic registries), but loadData() and freeze() only iterated RegistryDataLoader.WORLDGEN_REGISTRIES (vanilla only). This left Fabric registries permanently unfrozen, causing Invalid method used for tag loading' crash during /reload.

I'm no longer experiencing error message in chat after /reload, with my custom tags. You can test it on your end everything should be the same as before.

[05:50:28] [Server thread/WARN] (Minecraft) Failed to execute reload java.util.concurrent.CompletionException: java.lang.IllegalStateException: Invalid method used for tag loading